### PR TITLE
Fix structs with keys as reserved keywords

### DIFF
--- a/sqlalchemy_bigquery/_struct.py
+++ b/sqlalchemy_bigquery/_struct.py
@@ -78,7 +78,7 @@ class STRUCT(sqlalchemy.sql.sqltypes.Indexable, sqlalchemy.types.UserDefinedType
 
     def get_col_spec(self, **kw):
         fields = ", ".join(
-            f"{name} {_get_subtype_col_spec(type_)}"
+            f"`{name}` {_get_subtype_col_spec(type_)}"
             for name, type_ in self._STRUCT_fields
         )
         return f"STRUCT<{fields}>"


### PR DESCRIPTION
Struct keys that contain reserved keywords need to be quoted (https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#reserved_keywords)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-sqlalchemy/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
